### PR TITLE
Render drawins using layer shell

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,8 @@ set(AWE_SRCS
     ${BUILD_DIR}/objects/tag.c
     ${BUILD_DIR}/objects/selection_getter.c
     ${BUILD_DIR}/objects/window.c
+    ${BUILD_DIR}/wayland/drawin.c
+    ${BUILD_DIR}/wayland/drawable.c
     ${BUILD_DIR}/wayland/mousegrabber.c
     ${BUILD_DIR}/wayland/globals.c
     ${BUILD_DIR}/wayland/root.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ set(AWE_SRCS
     ${BUILD_DIR}/wayland/mousegrabber.c
     ${BUILD_DIR}/wayland/globals.c
     ${BUILD_DIR}/wayland/root.c
+    ${BUILD_DIR}/x11/drawin.c
     ${BUILD_DIR}/x11/drawable.c
     ${BUILD_DIR}/x11/mousegrabber.c
     ${BUILD_DIR}/x11/globals.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ set(AWE_SRCS
     ${BUILD_DIR}/wayland/mousegrabber.c
     ${BUILD_DIR}/wayland/globals.c
     ${BUILD_DIR}/wayland/root.c
+    ${BUILD_DIR}/x11/drawable.c
     ${BUILD_DIR}/x11/mousegrabber.c
     ${BUILD_DIR}/x11/globals.c
     ${BUILD_DIR}/x11/root.c

--- a/awesomeConfig.cmake
+++ b/awesomeConfig.cmake
@@ -221,6 +221,8 @@ if (WAYLAND_FOUND)
     set(AWESOME_OPTIONAL_INCLUDE_DIRS ${AWESOME_OPTIONAL_INCLUDE_DIRS} ${WAYLAND_INCLUDE_DIRS})
 endif()
 
+set(AWESOME_OPTIONAL_LDFLAGS ${AWESOME_OPTIONAL_LDFLAGS} -lrt)
+
 set(protos
     "/usr/share/wayland-protocols/stable/xdg-shell/xdg-shell.xml"
     "../wayland/protocols/way-cooler-keybindings-unstable-v1.xml"

--- a/globalconf.h
+++ b/globalconf.h
@@ -228,6 +228,7 @@ typedef struct
     struct wl_compositor *wl_compositor;
     struct wl_shm *wl_shm;
     struct wl_seat *wl_seat;
+    struct zwlr_layer_shell_v1 *layer_shell;
 
     /* Awesome-specific Wayland globals */
     struct zway_cooler_mousegrabber *wl_mousegrabber;

--- a/mouse.c
+++ b/mouse.c
@@ -70,6 +70,8 @@
 #include "objects/drawin.h"
 #include "objects/screen.h"
 
+extern struct drawin_impl drawin_impl;
+
 static int miss_index_handler    = LUA_REFNIL;
 static int miss_newindex_handler = LUA_REFNIL;
 
@@ -288,7 +290,7 @@ luaA_mouse_object_under_pointer(lua_State *L)
     drawin_t *drawin;
     client_t *client;
 
-    if((drawin = drawin_getbywin(child)))
+    if((drawin = drawin_impl.get_drawin_by_window(child)))
         return luaA_object_push(L, drawin);
 
     if((client = client_getbyframewin(child)))

--- a/objects/client.c
+++ b/objects/client.c
@@ -107,6 +107,8 @@
 #include <xcb/shape.h>
 #include <cairo-xcb.h>
 
+extern struct drawable_impl drawable_impl;
+
 /** Client class.
  *
  * This table allow to add more dynamic properties to the clients. For example,
@@ -2836,9 +2838,10 @@ client_get_drawable(client_t *c, int x, int y)
 static void
 client_refresh_titlebar_partial(client_t *c, client_titlebar_t bar, int16_t x, int16_t y, uint16_t width, uint16_t height)
 {
-    if(c->titlebar[bar].drawable == NULL
-            || c->titlebar[bar].drawable->pixmap == XCB_NONE
-            || !c->titlebar[bar].drawable->refreshed)
+    struct drawable_t *drawable = c->titlebar[bar].drawable;
+    if(drawable == NULL
+            || drawable_impl.get_pixmap(drawable) == XCB_NONE
+            || drawable->refreshed)
         return;
 
     /* Is the titlebar part of the area that should get redrawn? */
@@ -2849,9 +2852,10 @@ client_refresh_titlebar_partial(client_t *c, client_titlebar_t bar, int16_t x, i
         return;
 
     /* Redraw the affected parts */
-    cairo_surface_flush(c->titlebar[bar].drawable->surface);
-    xcb_copy_area(globalconf.connection, c->titlebar[bar].drawable->pixmap, c->frame_window,
-            globalconf.gc, x - area.x, y - area.y, x, y, width, height);
+    cairo_surface_flush(drawable->surface);
+    xcb_copy_area(globalconf.connection, drawable_impl.get_pixmap(drawable),
+            c->frame_window, globalconf.gc, x - area.x, y - area.y,
+            x, y, width, height);
 }
 
 #define HANDLE_TITLEBAR_REFRESH(name, index)                                                \

--- a/objects/drawable.h
+++ b/objects/drawable.h
@@ -28,12 +28,25 @@
 
 typedef void drawable_refresh_callback(void *);
 
+struct drawable_t;
+
+struct drawable_impl
+{
+    xcb_pixmap_t (*get_pixmap)(struct drawable_t *drawable);
+
+    /* Drawable private functions */
+    void (*drawable_allocate)(struct drawable_t *drawable);
+    void (*drawable_unset_surface)(struct drawable_t *drawable);
+    void (*drawable_allocate_buffer)(struct drawable_t *drawable);
+    void (*drawable_cleanup)(struct drawable_t *drawable);
+};
+
 /** drawable type */
 struct drawable_t
 {
     LUA_OBJECT_HEADER
-    /** The pixmap we are drawing to. */
-    xcb_pixmap_t pixmap;
+    /* XXX This data should only be cast from drawable_impl functions */
+    void *impl_data;
     /** Surface for drawing. */
     cairo_surface_t *surface;
     /** The geometry of the drawable (in root window coordinates). */

--- a/objects/drawin.c
+++ b/objects/drawin.c
@@ -47,6 +47,8 @@
 #include <cairo-xcb.h>
 #include <xcb/shape.h>
 
+extern struct drawable_impl drawable_impl;
+
 /** Drawin object.
  *
  * @field border_width Border width.
@@ -309,7 +311,7 @@ drawin_refresh_pixmap_partial(drawin_t *drawin,
                               int16_t x, int16_t y,
                               uint16_t w, uint16_t h)
 {
-    if (!drawin->drawable || !drawin->drawable->pixmap || !drawin->drawable->refreshed)
+    if (!drawin->drawable || !drawable_impl.get_pixmap(drawin->drawable) || !drawin->drawable->refreshed)
         return;
 
     /* Make sure it really has the size it should have */
@@ -317,7 +319,7 @@ drawin_refresh_pixmap_partial(drawin_t *drawin,
 
     /* Make cairo do all pending drawing */
     cairo_surface_flush(drawin->drawable->surface);
-    xcb_copy_area(globalconf.connection, drawin->drawable->pixmap,
+    xcb_copy_area(globalconf.connection, drawable_impl.get_pixmap(drawin->drawable),
                   drawin->window, globalconf.gc, x, y, x, y,
                   w, h);
 }

--- a/stack.c
+++ b/stack.c
@@ -168,6 +168,10 @@ stack_refresh()
     if(!need_stack_refresh)
         return;
 
+    // FIXME
+    if (globalconf.wl_display != NULL)
+        return;
+
     xcb_window_t next = XCB_NONE;
 
     /* stack desktop windows */

--- a/stack.c
+++ b/stack.c
@@ -25,6 +25,8 @@
 
 #include "x11/ewmh.h"
 
+extern struct drawin_impl drawin_impl;
+
 void
 stack_client_remove(client_t *c)
 {
@@ -178,8 +180,10 @@ stack_refresh()
     foreach(drawin, globalconf.drawins)
         if(!(*drawin)->ontop)
         {
-            stack_window_above((*drawin)->window, next);
-            next = (*drawin)->window;
+            xcb_window_t window = drawin_impl.get_xcb_window(*drawin);
+            stack_window_above(window, next);
+            window = drawin_impl.get_xcb_window(*drawin);
+            next = window;
         }
 
     /* then stack clients */
@@ -192,8 +196,9 @@ stack_refresh()
     foreach(drawin, globalconf.drawins)
         if((*drawin)->ontop)
         {
-            stack_window_above((*drawin)->window, next);
-            next = (*drawin)->window;
+            xcb_window_t window = drawin_impl.get_xcb_window(*drawin);
+            stack_window_above(window, next);
+            next = window;
         }
 
     need_stack_refresh = false;

--- a/systray.c
+++ b/systray.c
@@ -33,6 +33,8 @@
 
 #define SYSTEM_TRAY_REQUEST_DOCK 0 /* Begin icon docking */
 
+extern struct drawin_impl drawin_impl;
+
 /** Initialize systray information in X.
  */
 void
@@ -369,10 +371,13 @@ luaA_systray(lua_State *L)
         }
 
         if(globalconf.systray.parent != w)
+        {
+            xcb_window_t window = drawin_impl.get_xcb_window(w);
             xcb_reparent_window(globalconf.connection,
                                 globalconf.systray.window,
-                                w->window,
+                                window,
                                 x, y);
+        }
         else
         {
             uint32_t config_vals[2] = { x, y };

--- a/wayland/drawable.c
+++ b/wayland/drawable.c
@@ -1,0 +1,150 @@
+/*
+ * Copyright © 2019 Preston Carpenter <APragmaticPlace@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "drawable.h"
+
+#include <stdlib.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/mman.h>
+
+#include <wayland-client.h>
+
+#include "wlr-layer-shell-unstable-v1.h"
+#include "globalconf.h"
+
+const char *anon_prefix = "/wayland-";
+
+static int anon_file(void)
+{
+    char name[32] = {0};
+    strncpy(name, anon_prefix, sizeof(name));
+    for (char *cursor = name + strlen(anon_prefix);
+         cursor < name + sizeof(name) - 1;
+         cursor++)
+    {
+        long int num = random();
+        char c = (num % 26) + 65;
+        *cursor = c;
+    }
+    name[31] = '\0';
+    int fd = shm_open(name, O_RDWR | O_CREAT | O_EXCL, 0600);
+    shm_unlink(name);
+    return fd;
+}
+
+static void setup_buffer(area_t geo, int stride, struct wl_buffer **out_buffer,
+        void **out_shm_data, size_t *size)
+{
+    assert(out_buffer);
+    assert(out_shm_data);
+    assert(size);
+
+    if (*out_shm_data != NULL) {
+        munmap(*out_shm_data, *size);
+        *out_shm_data = NULL;
+        *size = 0;
+    }
+
+    *size = stride * geo.height;
+    if (*size == 0)
+        return;
+
+    int fd = anon_file();
+    if (fd < 0)
+        fatal("Could not allocate any wl_shm_pools buffers");
+    if (ftruncate(fd, *size) < 0)
+        fatal("Could not resize shared memory file");
+
+    *out_shm_data = mmap(NULL, *size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+	if (*out_shm_data == MAP_FAILED)
+        fatal("mmap failed");
+
+	struct wl_shm_pool *pool = wl_shm_create_pool(globalconf.wl_shm, fd, *size);
+    assert(pool);
+
+    *out_buffer = wl_shm_pool_create_buffer(pool, 0,
+            geo.width, geo.height, stride, WL_SHM_FORMAT_ARGB8888);
+    assert(*out_buffer);
+
+    wl_shm_pool_destroy(pool);
+    close(fd);
+}
+
+xcb_pixmap_t wayland_get_pixmap(struct drawable_t *drawable)
+{
+    fatal("Attempted to get an X11 pixmap while using Wayland");
+}
+
+void wayland_drawable_allocate(struct drawable_t *drawable)
+{
+    drawable->impl_data = calloc(1, sizeof(struct wayland_drawable));
+
+    struct wayland_drawable *wayland_drawable = drawable->impl_data;
+    wayland_drawable->wl_surface =
+        wl_compositor_create_surface(globalconf.wl_compositor);
+}
+
+void wayland_drawable_cleanup(struct drawable_t *drawable)
+{
+    wayland_drawable_unset_surface(drawable);
+
+    struct wayland_drawable *wayland_drawable = drawable->impl_data;
+    if (wayland_drawable->wl_surface != NULL)
+        wl_surface_destroy(wayland_drawable->wl_surface);
+
+    free(drawable->impl_data);
+    drawable->impl_data = NULL;
+}
+
+void wayland_drawable_create_buffer(struct drawable_t *drawable)
+{
+    struct wayland_drawable *wayland_drawable = drawable->impl_data;
+
+    if (drawable->geometry.width == 0 || drawable->geometry.height == 0)
+        return;
+    int stride = cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32,
+            drawable->geometry.width);
+
+    wayland_drawable_unset_surface(drawable);
+    setup_buffer(drawable->geometry, stride,
+            &wayland_drawable->buffer, &wayland_drawable->shm_data,
+            &wayland_drawable->shm_size);
+
+    drawable->surface =
+        cairo_image_surface_create_for_data(wayland_drawable->shm_data,
+                CAIRO_FORMAT_ARGB32, drawable->geometry.width,
+                drawable->geometry.height,
+                stride);
+}
+
+void wayland_drawable_unset_surface(struct drawable_t *drawable)
+{
+    struct wayland_drawable *wayland_drawable = drawable->impl_data;
+
+    if (wayland_drawable->wl_surface != NULL && wayland_drawable->buffer != NULL)
+    {
+        wl_surface_attach(wayland_drawable->wl_surface, NULL, 0, 0);
+        wl_buffer_destroy(wayland_drawable->buffer);
+        wayland_drawable->buffer = NULL;
+    }
+
+}
+// vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/wayland/drawable.h
+++ b/wayland/drawable.h
@@ -1,7 +1,5 @@
 /*
- * Copyright © 2007-2009 Julien Danjou <julien@danjou.info>
- * Copyright © 2010-2012 Uli Schlachter <psychon@znc.in>
- * Copyright ©      2019 Preston Carpenter <APragmaticPlace@gmail.com>
+ * Copyright © 2019 Preston Carpenter <APragmaticPlace@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,26 +17,26 @@
  *
  */
 
-#ifndef AWESOME_X11_DRAWABLE_H
-#define AWESOME_X11_DRAWABLE_H
-
-#include <xcb/xcb_atom.h>
-#include <xcb/xcb_aux.h>
+#ifndef AWESOME_WAYLAND_DRAWABLE_H
+#define AWESOME_WAYLAND_DRAWABLE_H
 
 #include "objects/drawable.h"
 
-struct x11_drawable
+struct wayland_drawable
 {
-	xcb_pixmap_t pixmap;
+    struct wl_surface *wl_surface;
+    struct wl_buffer *buffer;
+    void *shm_data;
+	size_t shm_size;
 };
 
-xcb_pixmap_t x11_get_pixmap(struct drawable_t *drawable);
+xcb_pixmap_t wayland_get_pixmap(struct drawable_t *drawable);
 
-void x11_drawable_allocate(struct drawable_t *drawable);
-void x11_drawable_cleanup(struct drawable_t *drawable);
-void x11_drawable_unset_surface(struct drawable_t *drawable);
-void x11_drawable_wipe(struct drawable_t *drawable);
-void x11_drawable_create_pixmap(struct drawable_t *drawable);
+void wayland_drawable_allocate(struct drawable_t *drawable);
+void wayland_drawable_cleanup(struct drawable_t *drawable);
+void wayland_drawable_unset_surface(struct drawable_t *drawable);
+void wayland_drawable_wipe(struct drawable_t *drawable);
+void wayland_drawable_create_buffer(struct drawable_t *drawable);
 
-#endif  // AWESOME_X11_DRAWABLE_H
+#endif // AWESOME_WAYLAND_DRAWABLE_H
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/wayland/drawin.c
+++ b/wayland/drawin.c
@@ -1,0 +1,263 @@
+/*
+ * Copyright © 2019 Preston Carpenter <APragmaticPlace@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+#include "wayland/drawin.h"
+
+#include <stdint.h>
+
+#include <wayland-client.h>
+#include "wlr-layer-shell-unstable-v1.h"
+
+#include "wayland/drawable.h"
+#include "globalconf.h"
+
+static void layer_surface_configure(void *data,
+        struct zwlr_layer_surface_v1 *surface,
+        uint32_t serial, uint32_t w, uint32_t h)
+{
+    struct drawin_t *drawin = data;
+    struct wayland_drawin *wayland_drawin = drawin->impl_data;
+    struct wayland_drawable *wayland_drawable = drawin->drawable->impl_data;
+
+    drawin->geometry.width = w;
+    drawin->geometry.height = h;
+
+    drawin_apply_moveresize(drawin);
+
+    zwlr_layer_surface_v1_ack_configure(surface, serial);
+    wayland_drawin->configured = true;
+
+    if (wayland_drawin->mapped)
+        wl_surface_attach(wayland_drawable->wl_surface,
+                wayland_drawable->buffer, 0, 0);
+}
+
+static void layer_surface_closed(void *data,
+        struct zwlr_layer_surface_v1 *surface)
+{
+    struct drawin_t *drawin = data;
+    struct wayland_drawin *wayland_drawin = drawin->impl_data;
+
+	zwlr_layer_surface_v1_destroy(wayland_drawin->layer_surface);
+    wayland_drawable_cleanup(drawin->drawable);
+
+    wayland_drawin->layer_surface = NULL;
+}
+
+struct zwlr_layer_surface_v1_listener layer_surface_listener =
+{
+	.configure = layer_surface_configure,
+	.closed = layer_surface_closed,
+};
+
+xcb_window_t wayland_get_xcb_window(struct drawin_t *drawin)
+{
+    fatal("Attempted to get an xcb window while using Wayland\n");
+}
+
+drawin_t *wayland_get_drawin_by_window(xcb_window_t win)
+{
+    fatal("Attempted to get a drawin using a xcb_window_t while using Wayland");
+}
+
+void wayland_drawin_allocate(struct drawin_t *drawin)
+{
+    drawin->impl_data = calloc(1, sizeof(struct wayland_drawin));
+
+    struct wayland_drawin *wayland_drawin = drawin->impl_data;
+    struct wayland_drawable *wayland_drawable = drawin->drawable->impl_data;
+    struct zwlr_layer_shell_v1 *layer_shell = globalconf.layer_shell;
+
+    assert(wayland_drawable->wl_surface);
+
+    wayland_drawin->layer_surface =
+        zwlr_layer_shell_v1_get_layer_surface(layer_shell,
+                wayland_drawable->wl_surface, NULL,
+                ZWLR_LAYER_SHELL_V1_LAYER_TOP, "awesome");
+    zwlr_layer_surface_v1_set_size(wayland_drawin->layer_surface,
+            drawin->geometry.width, drawin->geometry.height);
+	zwlr_layer_surface_v1_set_keyboard_interactivity(
+			wayland_drawin->layer_surface, true);
+	zwlr_layer_surface_v1_add_listener(wayland_drawin->layer_surface,
+			&layer_surface_listener, drawin);
+
+    // XXX This is to get around not being able to set explicit x/y coordinates.
+    // We anchor to the top left and then use the margins to set ourselves.
+    zwlr_layer_surface_v1_set_anchor(wayland_drawin->layer_surface,
+            ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP | ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT);
+    wayland_drawin->configured = false;
+    wayland_drawin->mapped = false;
+
+	wl_surface_commit(wayland_drawable->wl_surface);
+	wl_display_roundtrip(globalconf.wl_display);
+}
+
+void wayland_drawin_cleanup(struct drawin_t *drawin)
+{
+    struct wayland_drawin *wayland_drawin = drawin->impl_data;
+
+    zwlr_layer_surface_v1_destroy(wayland_drawin->layer_surface);
+
+    free(wayland_drawin);
+    drawin->impl_data = NULL;
+}
+
+void wayland_drawin_moveresize(struct drawin_t *drawin)
+{
+    struct wayland_drawin *wayland_drawin = drawin->impl_data;
+    struct wayland_drawable *wayland_drawable = drawin->drawable->impl_data;
+
+    assert(wayland_drawin->layer_surface);
+    assert(wayland_drawable->wl_surface);
+
+    zwlr_layer_surface_v1_set_size(wayland_drawin->layer_surface,
+            drawin->geometry.width, drawin->geometry.height);
+    zwlr_layer_surface_v1_set_margin(wayland_drawin->layer_surface,
+            drawin->geometry.y, 0, 0, drawin->geometry.x);
+
+    if (wayland_drawin->mapped)
+    {
+        wl_surface_attach(wayland_drawable->wl_surface,
+                wayland_drawable->buffer, 0, 0);
+        wl_surface_damage_buffer(wayland_drawable->wl_surface,
+                drawin->geometry.x, drawin->geometry.y,
+                drawin->geometry.width, drawin->geometry.height);
+        wl_surface_commit(wayland_drawable->wl_surface);
+        wl_display_roundtrip(globalconf.wl_display);
+    }
+}
+
+void wayland_drawin_refresh(struct drawin_t *drawin, int16_t x, int16_t y,
+        uint16_t w, uint16_t h)
+{
+    struct wayland_drawin *wayland_drawin = drawin->impl_data;
+    struct wayland_drawable *wayland_drawable = drawin->drawable->impl_data;
+
+    assert(wayland_drawin->layer_surface);
+    assert(drawin->drawable);
+
+    if (!drawin->drawable->refreshed)
+        return;
+
+    /* Make sure it really has the size it should have */
+    drawin_apply_moveresize(drawin);
+
+    /* Make cairo do all pending drawing */
+    cairo_surface_flush(drawin->drawable->surface);
+
+    if (wayland_drawin->mapped)
+    {
+        wl_surface_attach(wayland_drawable->wl_surface,
+                wayland_drawable->buffer, 0, 0);
+        wl_surface_damage_buffer(wayland_drawable->wl_surface, x, y, w, h);
+        wl_surface_commit(wayland_drawable->wl_surface);
+        wl_display_roundtrip(globalconf.wl_display);
+    }
+}
+
+void wayland_drawin_map(struct drawin_t *drawin)
+{
+    struct wayland_drawin *wayland_drawin = drawin->impl_data;
+    struct wayland_drawable *wayland_drawable = drawin->drawable->impl_data;
+
+    assert(wayland_drawin->layer_surface);
+
+    wl_surface_attach(wayland_drawable->wl_surface, wayland_drawable->buffer, 0, 0);
+
+    if (wayland_drawin->configured)
+    {
+        wayland_drawin->mapped = true;
+
+        wl_surface_damage_buffer(wayland_drawable->wl_surface, 0, 0,
+                drawin->geometry.width, drawin->geometry.height);
+        wl_surface_commit(wayland_drawable->wl_surface);
+        wl_display_roundtrip(globalconf.wl_display);
+    }
+
+}
+
+void wayland_drawin_unmap(struct drawin_t *drawin)
+{
+    struct wayland_drawin *wayland_drawin = drawin->impl_data;
+    struct wayland_drawable *wayland_drawable = drawin->drawable->impl_data;
+
+    assert(wayland_drawin->layer_surface);
+
+    if (wayland_drawin->configured)
+    {
+        wayland_drawin->mapped = false;
+
+        wayland_drawable_unset_surface(drawin->drawable);
+        wl_surface_damage_buffer(wayland_drawable->wl_surface, 0, 0,
+                drawin->geometry.width, drawin->geometry.height);
+        wl_surface_commit(wayland_drawable->wl_surface);
+        wl_display_roundtrip(globalconf.wl_display);
+    }
+
+}
+
+double wayland_drawin_get_opacity(struct drawin_t *drawin)
+{
+    // TODO
+    return 1.0;
+}
+
+void wayland_drawin_set_cursor(struct drawin_t *drawin, const char *cursor)
+{
+    // TODO
+}
+
+void wayland_drawin_systray_kickout(struct drawin_t *drawin)
+{
+    // TODO
+}
+
+void wayland_drawin_set_shape_bounding(struct drawin_t *drawin,
+        cairo_surface_t *surface)
+{
+    // TODO
+}
+
+void wayland_drawin_set_shape_clip(struct drawin_t *drawin,
+        cairo_surface_t *surface)
+{
+    // TODO
+}
+
+void wayland_drawin_set_shape_input(struct drawin_t *drawin,
+        cairo_surface_t *surface)
+{
+    // TODO
+}
+
+cairo_surface_t *wayland_drawin_get_shape_bounding(struct drawin_t *drawin)
+{
+    abort();
+}
+
+cairo_surface_t *wayland_drawin_get_shape_clip(struct drawin_t *drawin)
+{
+    abort();
+}
+
+cairo_surface_t *wayland_drawin_get_shape_input(struct drawin_t *drawin)
+{
+    abort();
+}
+
+// vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/wayland/drawin.h
+++ b/wayland/drawin.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2019 Preston Carpenter <APragmaticPlace@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+#ifndef AWESOME_WAYLAND_DRAWIN_H
+#define AWESOME_WAYLAND_DRAWIN_H
+
+#include "objects/drawin.h"
+
+#include "wlr-layer-shell-unstable-v1.h"
+
+struct wayland_drawin
+{
+    struct zwlr_layer_surface_v1 *layer_surface;
+    bool configured;
+    bool mapped;
+};
+
+xcb_window_t wayland_get_xcb_window(struct drawin_t *drawin);
+drawin_t *wayland_get_drawin_by_window(xcb_window_t win);
+
+void wayland_drawin_allocate(struct drawin_t *drawin);
+void wayland_drawin_cleanup(struct drawin_t *drawin);
+void wayland_drawin_moveresize(struct drawin_t *drawin);
+void wayland_drawin_refresh(struct drawin_t *drawin, int16_t x, int16_t y,
+        uint16_t w, uint16_t h);
+void wayland_drawin_map(struct drawin_t *drawin);
+void wayland_drawin_unmap(struct drawin_t *drawin);
+double wayland_drawin_get_opacity(struct drawin_t *drawin);
+void wayland_drawin_set_cursor(struct drawin_t *drawin, const char *cursor);
+void wayland_drawin_systray_kickout(struct drawin_t *drawin);
+
+void wayland_drawin_set_shape_bounding(struct drawin_t *drawin,
+        cairo_surface_t *surface);
+void wayland_drawin_set_shape_clip(struct drawin_t *drawin,
+        cairo_surface_t *surface);
+void wayland_drawin_set_shape_input(struct drawin_t *drawin,
+        cairo_surface_t *surface);
+cairo_surface_t *wayland_drawin_get_shape_bounding(struct drawin_t *drawin);
+cairo_surface_t *wayland_drawin_get_shape_clip(struct drawin_t *drawin);
+cairo_surface_t *wayland_drawin_get_shape_input(struct drawin_t *drawin);
+
+
+#endif // AWESOME_WAYLAND_DRAWIN_H
+// vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/x11/drawable.c
+++ b/x11/drawable.c
@@ -1,5 +1,7 @@
 /*
- * Copyright © 2019 Preston Carpenter <APragmaticPlace@gmail.com>
+ * Copyright © 2008-2009 Julien Danjou <julien@danjou.info>
+ * Copyright © 2010-2012 Uli Schlachter <psychon@znc.in>
+ * Copyright ©      2019 Preston Carpenter <APragmaticPlace@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/x11/drawable.c
+++ b/x11/drawable.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2019 Preston Carpenter <APragmaticPlace@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "drawable.h"
+
+#include <cairo-xcb.h>
+
+#include "globalconf.h"
+
+xcb_pixmap_t x11_get_pixmap(struct drawable_t *drawable)
+{
+    assert(drawable->impl_data);
+    struct x11_drawable *x11_data = drawable->impl_data;
+    return x11_data->pixmap;
+}
+
+void x11_drawable_allocate(struct drawable_t *drawable)
+{
+    if (!drawable->impl_data)
+    {
+        drawable->impl_data = calloc(1, sizeof(struct x11_drawable));
+    }
+
+    struct x11_drawable *x11_data = drawable->impl_data;
+    x11_data->pixmap = XCB_NONE;
+}
+void x11_drawable_unset_surface(struct drawable_t *drawable)
+{
+
+    assert(drawable->impl_data);
+    struct x11_drawable *x11_data = drawable->impl_data;
+
+    if (x11_data->pixmap)
+    {
+        xcb_free_pixmap(globalconf.connection, x11_data->pixmap);
+    }
+    x11_data->pixmap = XCB_NONE;
+
+}
+
+void x11_drawable_create_pixmap(struct drawable_t *drawable)
+{
+    assert(drawable->impl_data);
+    struct x11_drawable *x11_data = drawable->impl_data;
+
+    x11_data->pixmap = xcb_generate_id(globalconf.connection);
+    xcb_create_pixmap(globalconf.connection, globalconf.default_depth, x11_data->pixmap,
+            globalconf.screen->root, drawable->geometry.width, drawable->geometry.height);
+    drawable->surface = cairo_xcb_surface_create(globalconf.connection,
+            x11_data->pixmap, globalconf.visual,
+            drawable->geometry.width, drawable->geometry.height);
+}
+
+void x11_drawable_cleanup(struct drawable_t *drawable)
+{
+    if (drawable->impl_data)
+    {
+        free(drawable->impl_data);
+        drawable->impl_data = NULL;
+    }
+}
+// vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/x11/drawable.h
+++ b/x11/drawable.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2019 Preston Carpenter <APragmaticPlace@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#ifndef AWESOME_X11_DRAWABLE_H
+#define AWESOME_X11_DRAWABLE_H
+
+#include <xcb/xcb_atom.h>
+#include <xcb/xcb_aux.h>
+
+#include "objects/drawable.h"
+
+struct x11_drawable
+{
+	xcb_pixmap_t pixmap;
+};
+
+xcb_pixmap_t x11_get_pixmap(struct drawable_t *drawable);
+
+void x11_drawable_allocate(struct drawable_t *drawable);
+void x11_drawable_unset_surface(struct drawable_t *drawable);
+void x11_drawable_wipe(struct drawable_t *drawable);
+void x11_drawable_create_pixmap(struct drawable_t *drawable);
+void x11_drawable_cleanup(struct drawable_t *drawable);
+
+#endif  // AWESOME_X11_DRAWABLE_H
+// vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/x11/drawin.c
+++ b/x11/drawin.c
@@ -1,5 +1,7 @@
 /*
- * Copyright © 2019 Preston Carpenter <APragmaticPlace@gmail.com>
+ * Copyright © 2008-2009 Julien Danjou <julien@danjou.info>
+ * Copyright ©      2010 Uli Schlachter <psychon@znc.in>
+ * Copyright ©      2019 Preston Carpenter <APragmaticPlace@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/x11/drawin.c
+++ b/x11/drawin.c
@@ -1,0 +1,257 @@
+/*
+ * Copyright © 2019 Preston Carpenter <APragmaticPlace@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "drawin.h"
+
+#include <xcb/shape.h>
+
+#include "common/xcursor.h"
+#include "objects/drawin.h"
+#include "objects/client.h"
+#include "x11/xwindow.h"
+#include "x11/ewmh.h"
+
+extern struct drawable_impl drawable_impl;
+
+xcb_window_t x11_get_xcb_window(struct drawin_t *drawin)
+{
+    struct x11_drawin *x11_drawin = drawin->impl_data;
+    return x11_drawin->window;
+}
+
+/** Get a drawin by its window.
+ * \param win The window id.
+ * \return A drawin if found, NULL otherwise.
+ */
+drawin_t *x11_get_drawin_by_window(xcb_window_t win)
+{
+    foreach(w, globalconf.drawins)
+    {
+        struct x11_drawin *x11_drawin = (*w)->impl_data;
+        if(x11_drawin->window == win)
+            return *w;
+    }
+    return NULL;
+}
+
+void x11_drawin_allocate(struct drawin_t *drawin)
+{
+    if (!drawin->impl_data)
+    {
+        drawin->impl_data = calloc(1, sizeof(struct x11_drawin));
+    }
+
+    struct x11_drawin *x11_drawin = drawin->impl_data;
+    xcb_screen_t *s = globalconf.screen;
+
+    x11_drawin->window = xcb_generate_id(globalconf.connection);
+    xcb_create_window(globalconf.connection, globalconf.default_depth,
+            x11_drawin->window, s->root,
+            drawin->geometry.x, drawin->geometry.y,
+            drawin->geometry.width, drawin->geometry.height,
+            drawin->border_width, XCB_COPY_FROM_PARENT, globalconf.visual->visual_id,
+            XCB_CW_BORDER_PIXEL | XCB_CW_BIT_GRAVITY
+            | XCB_CW_OVERRIDE_REDIRECT | XCB_CW_EVENT_MASK | XCB_CW_COLORMAP
+            | XCB_CW_CURSOR,
+            (const uint32_t [])
+            {
+                drawin->border_color.pixel,
+                    XCB_GRAVITY_NORTH_WEST,
+                    1,
+                    XCB_EVENT_MASK_SUBSTRUCTURE_REDIRECT
+                    | XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY | XCB_EVENT_MASK_ENTER_WINDOW
+                    | XCB_EVENT_MASK_LEAVE_WINDOW | XCB_EVENT_MASK_STRUCTURE_NOTIFY
+                    | XCB_EVENT_MASK_POINTER_MOTION | XCB_EVENT_MASK_BUTTON_PRESS
+                    | XCB_EVENT_MASK_BUTTON_RELEASE | XCB_EVENT_MASK_EXPOSURE
+                    | XCB_EVENT_MASK_PROPERTY_CHANGE,
+                    globalconf.default_cmap,
+                    xcursor_new(globalconf.cursor_ctx,
+                            xcursor_font_fromstr(drawin->cursor))
+                    });
+    xwindow_set_class_instance(x11_drawin->window);
+    xwindow_set_name_static(x11_drawin->window, "Awesome drawin");
+
+    /* Set the right properties */
+    ewmh_update_window_type(x11_drawin->window,
+            window_translate_type(drawin->type));
+    ewmh_update_strut(x11_drawin->window, &drawin->strut);
+}
+
+void x11_drawin_cleanup(struct drawin_t *drawin)
+{
+    struct x11_drawin *x11_drawin = drawin->impl_data;
+
+    if(x11_drawin && x11_drawin->window)
+    {
+        /* Make sure we don't accidentally kill the systray window */
+        x11_drawin_systray_kickout(drawin);
+        xcb_destroy_window(globalconf.connection, x11_drawin->window);
+        x11_drawin->window = XCB_NONE;
+
+        free(x11_drawin);
+        drawin->impl_data = NULL;
+    }
+}
+
+void x11_drawin_moveresize(struct drawin_t *drawin)
+{
+    struct x11_drawin *x11_drawin = drawin->impl_data;
+
+    client_ignore_enterleave_events();
+    xcb_configure_window(globalconf.connection, x11_drawin->window,
+            XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y
+            | XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT,
+            (const uint32_t [])
+            {
+                drawin->geometry.x,
+                    drawin->geometry.y,
+                    drawin->geometry.width,
+                    drawin->geometry.height
+                    });
+    client_restore_enterleave_events();
+}
+
+/** Refresh the window content by copying its pixmap data to its window.
+ * \param drawin The drawin to refresh.
+ * \param x The copy starting point x component.
+ * \param y The copy starting point y component.
+ * \param w The copy width from the x component.
+ * \param h The copy height from the y component.
+ */
+void x11_drawin_refresh(struct drawin_t *drawin, int16_t x, int16_t y,
+        uint16_t w, uint16_t h)
+{
+    struct x11_drawin *x11_drawin = drawin->impl_data;
+
+    if (!drawin->drawable
+            || !drawable_impl.get_pixmap(drawin->drawable)
+            || !drawin->drawable->refreshed)
+        return;
+
+    /* Make sure it really has the size it should have */
+    drawin_apply_moveresize(drawin);
+
+    /* Make cairo do all pending drawing */
+    cairo_surface_flush(drawin->drawable->surface);
+    xcb_copy_area(globalconf.connection, drawable_impl.get_pixmap(drawin->drawable),
+            x11_drawin->window, globalconf.gc, x, y, x, y,
+            w, h);
+}
+
+void x11_drawin_map(struct drawin_t *drawin)
+{
+    struct x11_drawin *x11_drawin = drawin->impl_data;
+
+    xcb_map_window(globalconf.connection, x11_drawin->window);
+}
+
+void x11_drawin_unmap(struct drawin_t *drawin)
+{
+    struct x11_drawin *x11_drawin = drawin->impl_data;
+
+    xcb_unmap_window(globalconf.connection, x11_drawin->window);
+}
+
+double x11_drawin_get_opacity(struct drawin_t *drawin)
+{
+    struct x11_drawin *x11_drawin = drawin->impl_data;
+
+    return xwindow_get_opacity(x11_drawin->window);
+}
+
+void x11_drawin_set_cursor(struct drawin_t *drawin, const char *cursor_name)
+{
+    struct x11_drawin *x11_drawin = drawin->impl_data;
+
+    uint16_t cursor_font = xcursor_font_fromstr(cursor_name);
+    xcb_cursor_t cursor = xcursor_new(globalconf.cursor_ctx, cursor_font);
+    p_delete(&drawin->cursor);
+    drawin->cursor = a_strdup(cursor_name);
+    xwindow_set_cursor(x11_drawin->window, cursor);
+}
+
+void x11_drawin_systray_kickout(struct drawin_t *drawin)
+{
+    if(globalconf.systray.parent == drawin)
+    {
+        /* Who! Check that we're not deleting a drawin with a systray, because it
+         * may be its parent. If so, we reparent to root before, otherwise it will
+         * hurt very much. */
+        xcb_reparent_window(globalconf.connection,
+                globalconf.systray.window,
+                globalconf.screen->root,
+                -512, -512);
+
+        globalconf.systray.parent = NULL;
+    }
+}
+
+void x11_drawin_set_shape_bounding(struct drawin_t *drawin,
+        cairo_surface_t *surface)
+{
+    struct x11_drawin *x11_drawin = drawin->impl_data;
+
+    xwindow_set_shape(x11_drawin->window,
+            drawin->geometry.width + 2*drawin->border_width,
+            drawin->geometry.height + 2*drawin->border_width,
+            XCB_SHAPE_SK_BOUNDING, surface, -drawin->border_width);
+}
+
+void x11_drawin_set_shape_input(struct drawin_t *drawin,
+        cairo_surface_t *surface)
+{
+    struct x11_drawin *x11_drawin = drawin->impl_data;
+
+    xwindow_set_shape(x11_drawin->window,
+            drawin->geometry.width + 2*drawin->border_width,
+            drawin->geometry.height + 2*drawin->border_width,
+            XCB_SHAPE_SK_INPUT, surface, -drawin->border_width);
+}
+
+void x11_drawin_set_shape_clip(struct drawin_t *drawin,
+        cairo_surface_t *surface)
+{
+    struct x11_drawin *x11_drawin = drawin->impl_data;
+
+    xwindow_set_shape(x11_drawin->window, drawin->geometry.width,
+            drawin->geometry.height, XCB_SHAPE_SK_CLIP, surface, 0);
+}
+
+cairo_surface_t *x11_drawin_get_shape_clip(struct drawin_t *drawin)
+{
+    struct x11_drawin *x11_drawin = drawin->impl_data;
+
+    return xwindow_get_shape(x11_drawin->window, XCB_SHAPE_SK_CLIP);
+}
+
+cairo_surface_t *x11_drawin_get_shape_bounding(struct drawin_t *drawin)
+{
+    struct x11_drawin *x11_drawin = drawin->impl_data;
+
+    return xwindow_get_shape(x11_drawin->window, XCB_SHAPE_SK_BOUNDING);
+}
+
+cairo_surface_t *x11_drawin_get_shape_input(struct drawin_t *drawin)
+{
+    struct x11_drawin *x11_drawin = drawin->impl_data;
+
+    return xwindow_get_shape(x11_drawin->window, XCB_SHAPE_SK_INPUT);
+}
+
+// vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/x11/drawin.h
+++ b/x11/drawin.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2019 Preston Carpenter <APragmaticPlace@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+#ifndef AWESOME_X11_DRAWIN_H
+#define AWESOME_X11_DRAWIN_H
+
+#include "objects/drawin.h"
+
+struct x11_drawin
+{
+    /** The X window number */
+    xcb_window_t window;
+    /** The frame window, might be XCB_NONE */
+    xcb_window_t frame_window;
+};
+
+xcb_window_t x11_get_xcb_window(struct drawin_t *drawin);
+drawin_t *x11_get_drawin_by_window(xcb_window_t win);
+
+void x11_drawin_allocate(struct drawin_t *drawin);
+void x11_drawin_cleanup(struct drawin_t *drawin);
+void x11_drawin_moveresize(struct drawin_t *drawin);
+void x11_drawin_refresh(struct drawin_t *drawin, int16_t x, int16_t y,
+        uint16_t w, uint16_t h);
+void x11_drawin_map(struct drawin_t *drawin);
+void x11_drawin_unmap(struct drawin_t *drawin);
+double x11_drawin_get_opacity(struct drawin_t *drawin);
+void x11_drawin_set_cursor(struct drawin_t *drawin, const char *cursor);
+void x11_drawin_systray_kickout(struct drawin_t *drawin);
+
+void x11_drawin_set_shape_bounding(struct drawin_t *drawin,
+        cairo_surface_t *surface);
+void x11_drawin_set_shape_clip(struct drawin_t *drawin,
+        cairo_surface_t *surface);
+void x11_drawin_set_shape_input(struct drawin_t *drawin,
+        cairo_surface_t *surface);
+cairo_surface_t *x11_drawin_get_shape_bounding(struct drawin_t *drawin);
+cairo_surface_t *x11_drawin_get_shape_clip(struct drawin_t *drawin);
+cairo_surface_t *x11_drawin_get_shape_input(struct drawin_t *drawin);
+
+#endif // AWESOME_X11_DRAWIN_H
+// vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/x11/drawin.h
+++ b/x11/drawin.h
@@ -1,5 +1,7 @@
 /*
- * Copyright © 2019 Preston Carpenter <APragmaticPlace@gmail.com>
+ * Copyright © 2008-2009 Julien Danjou <julien@danjou.info>
+ * Copyright ©      2010 Uli Schlachter <psychon@znc.in>
+ * Copyright ©      2019 Preston Carpenter <APragmaticPlace@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/x11/globals.c
+++ b/x11/globals.c
@@ -19,16 +19,19 @@
 
 #include <stdbool.h>
 
+#include "objects/drawin.h"
 #include "objects/drawable.h"
 #include <mousegrabber.h>
 #include <root.h>
 
 #include "globalconf.h"
+#include "x11/drawin.h"
 #include "x11/drawable.h"
 #include "x11/root.h"
 #include "x11/mousegrabber.h"
 #include "x11/globals.h"
 
+extern struct drawin_impl drawin_impl;
 extern struct drawable_impl drawable_impl;
 extern struct mousegrabber_impl mousegrabber_impl;
 extern struct root_impl root_impl;
@@ -45,6 +48,25 @@ void init_x11(void)
     if (xcb_request_check(globalconf.connection, cookie))
         fatal("another window manager is already running (can't select SubstructureRedirect)");
 
+    drawin_impl = (struct drawin_impl){
+        .get_xcb_window = x11_get_xcb_window,
+        .get_drawin_by_window = x11_get_drawin_by_window,
+        .drawin_cleanup = x11_drawin_cleanup,
+        .drawin_allocate = x11_drawin_allocate,
+        .drawin_moveresize = x11_drawin_moveresize,
+        .drawin_refresh = x11_drawin_refresh,
+        .drawin_map = x11_drawin_map,
+        .drawin_unmap = x11_drawin_unmap,
+        .drawin_get_opacity = x11_drawin_get_opacity,
+        .drawin_set_cursor = x11_drawin_set_cursor,
+        .drawin_systray_kickout = x11_drawin_systray_kickout,
+        .drawin_get_shape_bounding = x11_drawin_get_shape_bounding,
+        .drawin_get_shape_clip = x11_drawin_get_shape_clip,
+        .drawin_get_shape_input = x11_drawin_get_shape_input,
+        .drawin_set_shape_bounding = x11_drawin_set_shape_bounding,
+        .drawin_set_shape_clip = x11_drawin_set_shape_clip,
+        .drawin_set_shape_input = x11_drawin_set_shape_input,
+    };
     drawable_impl = (struct drawable_impl){
         .get_pixmap = x11_get_pixmap,
         .drawable_allocate = x11_drawable_allocate,

--- a/x11/globals.c
+++ b/x11/globals.c
@@ -19,14 +19,17 @@
 
 #include <stdbool.h>
 
+#include "objects/drawable.h"
 #include <mousegrabber.h>
 #include <root.h>
 
 #include "globalconf.h"
-#include "root.h"
-#include "mousegrabber.h"
-#include "globals.h"
+#include "x11/drawable.h"
+#include "x11/root.h"
+#include "x11/mousegrabber.h"
+#include "x11/globals.h"
 
+extern struct drawable_impl drawable_impl;
 extern struct mousegrabber_impl mousegrabber_impl;
 extern struct root_impl root_impl;
 
@@ -42,6 +45,13 @@ void init_x11(void)
     if (xcb_request_check(globalconf.connection, cookie))
         fatal("another window manager is already running (can't select SubstructureRedirect)");
 
+    drawable_impl = (struct drawable_impl){
+        .get_pixmap = x11_get_pixmap,
+        .drawable_allocate = x11_drawable_allocate,
+        .drawable_unset_surface = x11_drawable_unset_surface,
+        .drawable_allocate_buffer = x11_drawable_create_pixmap,
+        .drawable_cleanup = x11_drawable_cleanup,
+    };
     mousegrabber_impl = (struct mousegrabber_impl){
         .grab_mouse = x11_grab_mouse,
         .release_mouse = x11_release_mouse,

--- a/x11/property.c
+++ b/x11/property.c
@@ -32,6 +32,8 @@
 
 #include <xcb/xcb_atom.h>
 
+extern struct drawin_impl drawin_impl;
+
 #define HANDLE_TEXT_PROPERTY(funcname, atom, setfunc) \
     xcb_get_property_cookie_t \
     property_get_##funcname(client_t *c) \
@@ -397,12 +399,12 @@ property_handle_net_wm_opacity(uint8_t state,
                                xcb_window_t window)
 {
     lua_State *L = globalconf_get_lua_State();
-    drawin_t *drawin = drawin_getbywin(window);
+    drawin_t *drawin = drawin_impl.get_drawin_by_window(window);
 
     if(drawin)
     {
         luaA_object_push(L, drawin);
-        window_set_opacity(L, -1, xwindow_get_opacity(drawin->window));
+        window_set_opacity(L, -1, drawin_impl.drawin_get_opacity(drawin));
         lua_pop(L, -1);
     }
     else
@@ -447,7 +449,7 @@ property_handle_propertynotify_xproperty(xcb_property_notify_event_t *ev)
     {
         obj = client_getbywin(ev->window);
         if(!obj)
-            obj = drawin_getbywin(ev->window);
+            obj = drawin_impl.get_drawin_by_window(ev->window);
         if(!obj)
             return;
     } else


### PR DESCRIPTION
This abstracts out the drawin and drawable implementations into separate backends. Under way-cooler drawins will use the layer shell protocol to update their contents on the screen.

Currently the drawins no longer respond to input, so it will not be as interactable as the previous X11 version (where you could, e.g, click on the tag and it will move to it, or the awesome icon and a right click menu appears). This will be fixed but I wanted to get this merged in before this got too big and gross.

Drawins render in the correct place (instead of being stacked all on (0,0: e.g. the top left corner) however their layering is incorrect. This is because they are all rendered on the same layer which is up to how way-cooler chooses to layer them. The systray needs to be special cased, like it is in the X11 version.