### PR TITLE
layer-shell wallpaper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ set(AWE_SRCS
     ${BUILD_DIR}/objects/tag.c
     ${BUILD_DIR}/objects/selection_getter.c
     ${BUILD_DIR}/objects/window.c
+    ${BUILD_DIR}/wayland/utils.c
     ${BUILD_DIR}/wayland/drawin.c
     ${BUILD_DIR}/wayland/drawable.c
     ${BUILD_DIR}/wayland/mousegrabber.c

--- a/awesome.c
+++ b/awesome.c
@@ -26,6 +26,7 @@
 #include "common/backtrace.h"
 #include "common/version.h"
 #include "common/xutil.h"
+#include "root.h"
 #include "xkb.h"
 #include "dbus.h"
 #include "globalconf.h"

--- a/awesome.c
+++ b/awesome.c
@@ -909,7 +909,7 @@ main(int argc, char **argv)
     xutil_ungrab_server(globalconf.connection);
 
     /* get the current wallpaper, from now on we are informed when it changes */
-    root_update_wallpaper();
+    root_impl.update_wallpaper();
 
     /* init lua */
     luaA_init(&xdg, &searchpath);

--- a/globalconf.h
+++ b/globalconf.h
@@ -244,8 +244,5 @@ static inline lua_State *globalconf_get_lua_State(void) {
     return globalconf.L.real_L_dont_use_directly;
 }
 
-/* Defined in root.c */
-void root_update_wallpaper(void);
-
 #endif
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/root.c
+++ b/root.c
@@ -41,13 +41,6 @@
 
 struct root_impl root_impl;
 
-
-void
-root_update_wallpaper(void)
-{
-    root_impl.update_wallpaper();
-}
-
 static xcb_keycode_t
 _string_to_key_code(const char *s)
 {

--- a/root.c
+++ b/root.c
@@ -37,166 +37,15 @@
 #include "keygrabber.h"
 #include "math.h"
 
-#include <xcb/xcb.h>
-#include <xcb/xkb.h>
 #include <xcb/xtest.h>
-#include <xcb/xcb_aux.h>
-#include <cairo-xcb.h>
 
 struct root_impl root_impl;
 
-static void
-root_set_wallpaper_pixmap(xcb_connection_t *c, xcb_pixmap_t p)
-{
-    xcb_get_property_cookie_t prop_c;
-    xcb_get_property_reply_t *prop_r;
-    const xcb_screen_t *screen = globalconf.screen;
-
-    /* We now have the pattern painted to the pixmap p. Now turn p into the root
-     * window's background pixmap.
-     */
-    xcb_change_window_attributes(c, screen->root, XCB_CW_BACK_PIXMAP, &p);
-    xcb_clear_area(c, 0, screen->root, 0, 0, 0, 0);
-
-    prop_c = xcb_get_property_unchecked(c, false,
-            screen->root, ESETROOT_PMAP_ID, XCB_ATOM_PIXMAP, 0, 1);
-
-    /* Theoretically, this should be enough to set the wallpaper. However, to
-     * make pseudo-transparency work, clients need a way to get the wallpaper.
-     * You can't query a window's back pixmap, so properties are (ab)used.
-     */
-    xcb_change_property(c, XCB_PROP_MODE_REPLACE, screen->root, _XROOTPMAP_ID, XCB_ATOM_PIXMAP, 32, 1, &p);
-    xcb_change_property(c, XCB_PROP_MODE_REPLACE, screen->root, ESETROOT_PMAP_ID, XCB_ATOM_PIXMAP, 32, 1, &p);
-
-    /* Now make sure that the old wallpaper is freed (but only do this for ESETROOT_PMAP_ID) */
-    prop_r = xcb_get_property_reply(c, prop_c, NULL);
-    if (prop_r && prop_r->value_len)
-    {
-        xcb_pixmap_t *rootpix = xcb_get_property_value(prop_r);
-        if (rootpix)
-            xcb_kill_client(c, *rootpix);
-    }
-    p_delete(&prop_r);
-}
-
-static bool
-root_set_wallpaper(cairo_pattern_t *pattern)
-{
-    lua_State *L = globalconf_get_lua_State();
-    xcb_connection_t *c = xcb_connect(NULL, NULL);
-    xcb_pixmap_t p = xcb_generate_id(c);
-    /* globalconf.connection should be connected to the same X11 server, so we
-     * can just use the info from that other connection.
-     */
-    const xcb_screen_t *screen = globalconf.screen;
-    uint16_t width = screen->width_in_pixels;
-    uint16_t height = screen->height_in_pixels;
-    bool result = false;
-    cairo_surface_t *surface;
-    cairo_t *cr;
-
-    if (xcb_connection_has_error(c))
-        goto disconnect;
-
-    /* Create a pixmap and make sure it is already created, because we are going
-     * to use it from the other X11 connection (Juggling with X11 connections
-     * is a really, really bad idea).
-     */
-    xcb_create_pixmap(c, screen->root_depth, p, screen->root, width, height);
-    xcb_aux_sync(c);
-
-    /* Now paint to the picture from the main connection so that cairo sees that
-     * it can tell the X server to copy between the (possible) old pixmap and
-     * the new one directly and doesn't need GetImage and PutImage.
-     */
-    surface = cairo_xcb_surface_create(globalconf.connection, p, draw_default_visual(screen), width, height);
-    cr = cairo_create(surface);
-    /* Paint the pattern to the surface */
-    cairo_set_source(cr, pattern);
-    cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
-    cairo_paint(cr);
-    cairo_destroy(cr);
-    cairo_surface_flush(surface);
-    xcb_aux_sync(globalconf.connection);
-
-    /* Change the wallpaper, without sending us a PropertyNotify event */
-    xcb_grab_server(globalconf.connection);
-    xcb_change_window_attributes(globalconf.connection,
-                                 globalconf.screen->root,
-                                 XCB_CW_EVENT_MASK,
-                                 (uint32_t[]) { 0 });
-    root_set_wallpaper_pixmap(globalconf.connection, p);
-    xcb_change_window_attributes(globalconf.connection,
-                                 globalconf.screen->root,
-                                 XCB_CW_EVENT_MASK,
-                                 ROOT_WINDOW_EVENT_MASK);
-    xutil_ungrab_server(globalconf.connection);
-
-    /* Make sure our pixmap is not destroyed when we disconnect. */
-    xcb_set_close_down_mode(c, XCB_CLOSE_DOWN_RETAIN_PERMANENT);
-
-    /* Tell Lua that the wallpaper changed */
-    cairo_surface_destroy(globalconf.wallpaper);
-    globalconf.wallpaper = surface;
-    signal_object_emit(L, &global_signals, "wallpaper_changed", 0);
-
-    result = true;
-disconnect:
-    xcb_aux_sync(c);
-    xcb_disconnect(c);
-    return result;
-}
 
 void
 root_update_wallpaper(void)
 {
-    xcb_get_property_cookie_t prop_c;
-    xcb_get_property_reply_t *prop_r;
-    xcb_get_geometry_cookie_t geom_c;
-    xcb_get_geometry_reply_t *geom_r;
-    xcb_pixmap_t *rootpix;
-
-    cairo_surface_destroy(globalconf.wallpaper);
-    globalconf.wallpaper = NULL;
-
-    prop_c = xcb_get_property_unchecked(globalconf.connection, false,
-            globalconf.screen->root, _XROOTPMAP_ID, XCB_ATOM_PIXMAP, 0, 1);
-    prop_r = xcb_get_property_reply(globalconf.connection, prop_c, NULL);
-
-    if (!prop_r || !prop_r->value_len)
-    {
-        p_delete(&prop_r);
-        return;
-    }
-
-    rootpix = xcb_get_property_value(prop_r);
-    if (!rootpix)
-    {
-        p_delete(&prop_r);
-        return;
-    }
-
-    geom_c = xcb_get_geometry_unchecked(globalconf.connection, *rootpix);
-    geom_r = xcb_get_geometry_reply(globalconf.connection, geom_c, NULL);
-    if (!geom_r)
-    {
-        p_delete(&prop_r);
-        return;
-    }
-
-    /* Only the default visual makes sense, so just the default depth */
-    if (geom_r->depth != draw_visual_depth(globalconf.screen, globalconf.default_visual->visual_id))
-        warn("Got a pixmap with depth %d, but the default depth is %d, continuing anyway",
-                geom_r->depth, draw_visual_depth(globalconf.screen, globalconf.default_visual->visual_id));
-
-    globalconf.wallpaper = cairo_xcb_surface_create(globalconf.connection,
-                                                    *rootpix,
-                                                    globalconf.default_visual,
-                                                    geom_r->width,
-                                                    geom_r->height);
-
-    p_delete(&prop_r);
-    p_delete(&geom_r);
+    root_impl.update_wallpaper();
 }
 
 static xcb_keycode_t
@@ -472,7 +321,7 @@ luaA_root_wallpaper(lua_State *L)
     if(lua_gettop(L) == 1)
     {
         cairo_pattern_t *pattern = (cairo_pattern_t *)lua_touserdata(L, -1);
-        lua_pushboolean(L, root_set_wallpaper(pattern));
+        lua_pushboolean(L, root_impl.set_wallpaper(pattern));
         /* Don't return the wallpaper, it's too easy to get memleaks */
         return 1;
     }

--- a/root.h
+++ b/root.h
@@ -17,8 +17,10 @@
  *
  */
 
+#include <stdbool.h>
 #include <xcb/xcb.h>
 #include <xcb/xkb.h>
+#include <cairo/cairo.h>
 
 #include "objects/key.h"
 
@@ -27,6 +29,8 @@
 
 struct root_impl
 {
+	int (*set_wallpaper)(cairo_pattern_t *pattern);
+	void (*update_wallpaper)(void);
     void (*grab_keys)(void);
 };
 

--- a/root.h
+++ b/root.h
@@ -30,6 +30,8 @@ struct root_impl
     void (*grab_keys)(void);
 };
 
+void root_update_wallpaper(void);
+
 void root_handle_key(key_array_t *arr, bool pushed_to_stack,
 		uint32_t timestamp, uint32_t keycode, uint16_t state,
         bool pressed, xcb_keysym_t keysym, struct root_impl *root);

--- a/root.h
+++ b/root.h
@@ -34,7 +34,7 @@ struct root_impl
     void (*grab_keys)(void);
 };
 
-void root_update_wallpaper(void);
+extern struct root_impl root_impl;
 
 void root_handle_key(key_array_t *arr, bool pushed_to_stack,
 		uint32_t timestamp, uint32_t keycode, uint16_t state,

--- a/wayland/drawable.c
+++ b/wayland/drawable.c
@@ -19,74 +19,13 @@
 
 #include "drawable.h"
 
-#include <stdlib.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <errno.h>
-#include <sys/mman.h>
+#include "wayland/utils.h"
 
 #include <wayland-client.h>
 
 #include "wlr-layer-shell-unstable-v1.h"
 #include "globalconf.h"
 
-const char *anon_prefix = "/wayland-";
-
-static int anon_file(void)
-{
-    char name[32] = {0};
-    strncpy(name, anon_prefix, sizeof(name));
-    for (char *cursor = name + strlen(anon_prefix);
-         cursor < name + sizeof(name) - 1;
-         cursor++)
-    {
-        long int num = random();
-        char c = (num % 26) + 65;
-        *cursor = c;
-    }
-    name[31] = '\0';
-    int fd = shm_open(name, O_RDWR | O_CREAT | O_EXCL, 0600);
-    shm_unlink(name);
-    return fd;
-}
-
-static void setup_buffer(area_t geo, int stride, struct wl_buffer **out_buffer,
-        void **out_shm_data, size_t *size)
-{
-    assert(out_buffer);
-    assert(out_shm_data);
-    assert(size);
-
-    if (*out_shm_data != NULL) {
-        munmap(*out_shm_data, *size);
-        *out_shm_data = NULL;
-        *size = 0;
-    }
-
-    *size = stride * geo.height;
-    if (*size == 0)
-        return;
-
-    int fd = anon_file();
-    if (fd < 0)
-        fatal("Could not allocate any wl_shm_pools buffers");
-    if (ftruncate(fd, *size) < 0)
-        fatal("Could not resize shared memory file");
-
-    *out_shm_data = mmap(NULL, *size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if (*out_shm_data == MAP_FAILED)
-        fatal("mmap failed");
-
-	struct wl_shm_pool *pool = wl_shm_create_pool(globalconf.wl_shm, fd, *size);
-    assert(pool);
-
-    *out_buffer = wl_shm_pool_create_buffer(pool, 0,
-            geo.width, geo.height, stride, WL_SHM_FORMAT_ARGB8888);
-    assert(*out_buffer);
-
-    wl_shm_pool_destroy(pool);
-    close(fd);
-}
 
 xcb_pixmap_t wayland_get_pixmap(struct drawable_t *drawable)
 {
@@ -120,13 +59,11 @@ void wayland_drawable_create_buffer(struct drawable_t *drawable)
 
     if (drawable->geometry.width == 0 || drawable->geometry.height == 0)
         return;
-    int stride = cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32,
-            drawable->geometry.width);
 
+    int stride = 0;
     wayland_drawable_unset_surface(drawable);
-    setup_buffer(drawable->geometry, stride,
-            &wayland_drawable->buffer, &wayland_drawable->shm_data,
-            &wayland_drawable->shm_size);
+    wayland_setup_buffer(drawable->geometry, &wayland_drawable->buffer,
+            &stride, &wayland_drawable->shm_data, &wayland_drawable->shm_size);
 
     drawable->surface =
         cairo_image_surface_create_for_data(wayland_drawable->shm_data,

--- a/wayland/globals.c
+++ b/wayland/globals.c
@@ -226,6 +226,8 @@ void init_wayland(void)
         .release_mouse = wayland_release_mouse,
     };
     root_impl = (struct root_impl){
+        .set_wallpaper = wayland_set_wallpaper,
+        .update_wallpaper = wayland_update_wallpaper,
         .grab_keys = wayland_grab_keys,
     };
 }

--- a/wayland/root.c
+++ b/wayland/root.c
@@ -19,13 +19,102 @@
 
 #include "globalconf.h"
 #include <root.h>
+#include "objects/screen.h"
 #include "common/array.h"
 #include "wayland/root.h"
 #include "way-cooler-keybindings-unstable-v1.h"
+#include "wlr-layer-shell-unstable-v1.h"
+#include "wayland/utils.h"
 
+#include <wayland-client.h>
+#include "wlr-layer-shell-unstable-v1.h"
 #include <xcb/xcb.h>
 
 extern struct root_impl root_impl;
+
+struct wayland_wallpaper
+{
+    cairo_surface_t *surface;
+    struct wl_surface *wl_surface;
+    struct wl_buffer *buffer;
+    struct zwlr_layer_surface_v1 *layer_surface;
+    void *shm_data;
+    size_t shm_size;
+};
+
+// TODO We need a list of them, for multi-head.
+static struct wayland_wallpaper wayland_wallpaper;
+
+static void wallpaper_surface_configure(void *data,
+        struct zwlr_layer_surface_v1 *surface,
+        uint32_t serial, uint32_t w, uint32_t h)
+{
+    zwlr_layer_surface_v1_ack_configure(surface, serial);
+
+    wl_surface_attach(wayland_wallpaper.wl_surface,
+            wayland_wallpaper.buffer, 0, 0);
+	wl_surface_commit(wayland_wallpaper.wl_surface);
+	wl_display_roundtrip(globalconf.wl_display);
+}
+
+static void wallpaper_surface_closed(void *data,
+        struct zwlr_layer_surface_v1 *surface)
+{
+	zwlr_layer_surface_v1_destroy(wayland_wallpaper.layer_surface);
+}
+
+struct zwlr_layer_surface_v1_listener wallpaper_surface_listener =
+{
+	.configure = wallpaper_surface_configure,
+	.closed = wallpaper_surface_closed,
+};
+
+int wayland_set_wallpaper(cairo_pattern_t *pattern)
+{
+    area_t area = {
+        .width = globalconf.primary_screen->geometry.width,
+        .height = globalconf.primary_screen->geometry.height,
+    };
+    int stride = 0;
+
+    wayland_setup_buffer(area, &wayland_wallpaper.buffer, &stride,
+            &wayland_wallpaper.shm_data, &wayland_wallpaper.shm_size);
+    wayland_wallpaper.surface =
+        cairo_image_surface_create_for_data(wayland_wallpaper.shm_data,
+                CAIRO_FORMAT_ARGB32, area.width, area.height, stride);
+    wayland_wallpaper.wl_surface =
+        wl_compositor_create_surface(globalconf.wl_compositor);
+
+    cairo_t *cr = cairo_create(wayland_wallpaper.surface);
+    /* Paint the pattern to the surface */
+    cairo_set_source(cr, pattern);
+    cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
+    cairo_paint(cr);
+    cairo_destroy(cr);
+    cairo_surface_flush(wayland_wallpaper.surface);
+
+    struct zwlr_layer_shell_v1 *layer_shell = globalconf.layer_shell;
+    wayland_wallpaper.layer_surface =
+        zwlr_layer_shell_v1_get_layer_surface(layer_shell,
+                wayland_wallpaper.wl_surface, NULL,
+                ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND, "awesome");
+    zwlr_layer_surface_v1_set_size(wayland_wallpaper.layer_surface,
+            area.width, area.height);
+    zwlr_layer_surface_v1_set_keyboard_interactivity(
+            wayland_wallpaper.layer_surface, false);
+    zwlr_layer_surface_v1_add_listener(wayland_wallpaper.layer_surface,
+            &wallpaper_surface_listener, NULL);
+
+    wl_surface_commit(wayland_wallpaper.wl_surface);
+    wl_display_roundtrip(globalconf.wl_display);
+
+    return true;
+}
+
+void wayland_update_wallpaper(void)
+{
+    fprintf(stderr, "TODO update wayland wallpaper\n");
+}
 
 static void on_key(void *data, struct zway_cooler_keybindings *keybindings,
         uint32_t time, uint32_t keycode, uint32_t state, uint32_t mods)

--- a/wayland/utils.c
+++ b/wayland/utils.c
@@ -52,10 +52,10 @@ static int anon_file(void)
 }
 
 void wayland_setup_buffer(area_t geo, struct wl_buffer **out_buffer,
-		int *out_stride, void **out_shm_data, size_t *shm_size)
+        int *out_stride, void **out_shm_data, size_t *shm_size)
 {
     assert(out_buffer);
-	assert(out_stride);
+    assert(out_stride);
     assert(out_shm_data);
     assert(shm_size);
 
@@ -77,10 +77,10 @@ void wayland_setup_buffer(area_t geo, struct wl_buffer **out_buffer,
         fatal("Could not resize shared memory file");
 
     *out_shm_data = mmap(NULL, *shm_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	if (*out_shm_data == MAP_FAILED)
+    if (*out_shm_data == MAP_FAILED)
         fatal("mmap failed");
 
-	struct wl_shm_pool *pool = wl_shm_create_pool(globalconf.wl_shm, fd, *shm_size);
+    struct wl_shm_pool *pool = wl_shm_create_pool(globalconf.wl_shm, fd, *shm_size);
     assert(pool);
 
     *out_buffer = wl_shm_pool_create_buffer(pool, 0,

--- a/wayland/utils.c
+++ b/wayland/utils.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2019 Preston Carpenter <APragmaticPlace@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ */
+
+#include "wayland/utils.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <sys/mman.h>
+
+#include <wayland-client.h>
+
+#include "draw.h"
+#include "globalconf.h"
+
+const char *anon_prefix = "/wayland-";
+
+static int anon_file(void)
+{
+    char name[32] = {0};
+    strncpy(name, anon_prefix, sizeof(name));
+    for (char *cursor = name + strlen(anon_prefix);
+         cursor < name + sizeof(name) - 1;
+         cursor++)
+    {
+        long int num = random();
+        char c = (num % 26) + 65;
+        *cursor = c;
+    }
+    name[31] = '\0';
+    int fd = shm_open(name, O_RDWR | O_CREAT | O_EXCL, 0600);
+    shm_unlink(name);
+    return fd;
+}
+
+void wayland_setup_buffer(area_t geo, struct wl_buffer **out_buffer,
+		int *out_stride, void **out_shm_data, size_t *shm_size)
+{
+    assert(out_buffer);
+	assert(out_stride);
+    assert(out_shm_data);
+    assert(shm_size);
+
+    if (*out_shm_data != NULL) {
+        munmap(*out_shm_data, *shm_size);
+        *out_shm_data = NULL;
+        *shm_size = 0;
+    }
+
+    *out_stride = cairo_format_stride_for_width(CAIRO_FORMAT_ARGB32, geo.width);
+    *shm_size = *out_stride * geo.height;
+    if (*shm_size == 0)
+        return;
+
+    int fd = anon_file();
+    if (fd < 0)
+        fatal("Could not allocate any wl_shm_pools buffers");
+    if (ftruncate(fd, *shm_size) < 0)
+        fatal("Could not resize shared memory file");
+
+    *out_shm_data = mmap(NULL, *shm_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+	if (*out_shm_data == MAP_FAILED)
+        fatal("mmap failed");
+
+	struct wl_shm_pool *pool = wl_shm_create_pool(globalconf.wl_shm, fd, *shm_size);
+    assert(pool);
+
+    *out_buffer = wl_shm_pool_create_buffer(pool, 0,
+            geo.width, geo.height, *out_stride, WL_SHM_FORMAT_ARGB8888);
+    assert(*out_buffer);
+
+    wl_shm_pool_destroy(pool);
+    close(fd);
+}
+
+// vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/wayland/utils.h
+++ b/wayland/utils.h
@@ -25,7 +25,7 @@
 #include "draw.h"
 
 void wayland_setup_buffer(area_t geo, struct wl_buffer **out_buffer,
-		int *out_stride, void **out_shm_data, size_t *shm_size);
+        int *out_stride, void **out_shm_data, size_t *shm_size);
 
 #endif // AWESOME_WAYLAND_UTILS_H
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/wayland/utils.h
+++ b/wayland/utils.h
@@ -17,19 +17,15 @@
  *
  */
 
-#include "way-cooler-keybindings-unstable-v1.h"
+#ifndef AWESOME_WAYLAND_UTILS_H
+#define AWESOME_WAYLAND_UTILS_H
 
-#ifndef AWESOME_WAYLAND_ROOT_H
-#define AWESOME_WAYLAND_ROOT_H
+#include <wayland-client.h>
 
-#include <cairo/cairo.h>
+#include "draw.h"
 
-extern struct zway_cooler_keybindings_listener keybindings_listener;
+void wayland_setup_buffer(area_t geo, struct wl_buffer **out_buffer,
+		int *out_stride, void **out_shm_data, size_t *shm_size);
 
-int wayland_set_wallpaper(cairo_pattern_t *pattern);
-void wayland_update_wallpaper(void);
-
-void wayland_grab_keys(void);
-
-#endif
+#endif // AWESOME_WAYLAND_UTILS_H
 // vim: filetype=c:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80

--- a/x11/globals.c
+++ b/x11/globals.c
@@ -79,6 +79,8 @@ void init_x11(void)
         .release_mouse = x11_release_mouse,
     };
     root_impl = (struct root_impl){
+        .set_wallpaper = x11_set_wallpaper,
+        .update_wallpaper = x11_update_wallpaper,
         .grab_keys = x11_grab_keys,
     };
 }

--- a/x11/property.c
+++ b/x11/property.c
@@ -19,6 +19,7 @@
  *
  */
 
+#include <root.h>
 #include "property.h"
 #include "common/atoms.h"
 #include "common/xutil.h"

--- a/x11/root.c
+++ b/x11/root.c
@@ -20,6 +20,164 @@
 #include "root.h"
 #include "globalconf.h"
 #include "xwindow.h"
+#include "common/atoms-extern.h"
+#include "common/xutil.h"
+
+#include <cairo-xcb.h>
+#include <xcb/xtest.h>
+#include <xcb/xcb_aux.h>
+
+static void
+root_set_wallpaper_pixmap(xcb_connection_t *c, xcb_pixmap_t p)
+{
+    xcb_get_property_cookie_t prop_c;
+    xcb_get_property_reply_t *prop_r;
+    const xcb_screen_t *screen = globalconf.screen;
+
+    /* We now have the pattern painted to the pixmap p. Now turn p into the root
+     * window's background pixmap.
+     */
+    xcb_change_window_attributes(c, screen->root, XCB_CW_BACK_PIXMAP, &p);
+    xcb_clear_area(c, 0, screen->root, 0, 0, 0, 0);
+
+    prop_c = xcb_get_property_unchecked(c, false,
+            screen->root, ESETROOT_PMAP_ID, XCB_ATOM_PIXMAP, 0, 1);
+
+    /* Theoretically, this should be enough to set the wallpaper. However, to
+     * make pseudo-transparency work, clients need a way to get the wallpaper.
+     * You can't query a window's back pixmap, so properties are (ab)used.
+     */
+    xcb_change_property(c, XCB_PROP_MODE_REPLACE, screen->root, _XROOTPMAP_ID, XCB_ATOM_PIXMAP, 32, 1, &p);
+    xcb_change_property(c, XCB_PROP_MODE_REPLACE, screen->root, ESETROOT_PMAP_ID, XCB_ATOM_PIXMAP, 32, 1, &p);
+
+    /* Now make sure that the old wallpaper is freed (but only do this for ESETROOT_PMAP_ID) */
+    prop_r = xcb_get_property_reply(c, prop_c, NULL);
+    if (prop_r && prop_r->value_len)
+    {
+        xcb_pixmap_t *rootpix = xcb_get_property_value(prop_r);
+        if (rootpix)
+            xcb_kill_client(c, *rootpix);
+    }
+    p_delete(&prop_r);
+}
+
+int x11_set_wallpaper(cairo_pattern_t *pattern)
+{
+    lua_State *L = globalconf_get_lua_State();
+    xcb_connection_t *c = xcb_connect(NULL, NULL);
+    xcb_pixmap_t p = xcb_generate_id(c);
+    /* globalconf.connection should be connected to the same X11 server, so we
+     * can just use the info from that other connection.
+     */
+    const xcb_screen_t *screen = globalconf.screen;
+    uint16_t width = screen->width_in_pixels;
+    uint16_t height = screen->height_in_pixels;
+    bool result = false;
+    cairo_surface_t *surface;
+    cairo_t *cr;
+
+    if (xcb_connection_has_error(c))
+        goto disconnect;
+
+    /* Create a pixmap and make sure it is already created, because we are going
+     * to use it from the other X11 connection (Juggling with X11 connections
+     * is a really, really bad idea).
+     */
+    xcb_create_pixmap(c, screen->root_depth, p, screen->root, width, height);
+    xcb_aux_sync(c);
+
+    /* Now paint to the picture from the main connection so that cairo sees that
+     * it can tell the X server to copy between the (possible) old pixmap and
+     * the new one directly and doesn't need GetImage and PutImage.
+     */
+    surface = cairo_xcb_surface_create(globalconf.connection, p, draw_default_visual(screen), width, height);
+    cr = cairo_create(surface);
+    /* Paint the pattern to the surface */
+    cairo_set_source(cr, pattern);
+    cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
+    cairo_paint(cr);
+    cairo_destroy(cr);
+    cairo_surface_flush(surface);
+    xcb_aux_sync(globalconf.connection);
+
+    /* Change the wallpaper, without sending us a PropertyNotify event */
+    xcb_grab_server(globalconf.connection);
+    xcb_change_window_attributes(globalconf.connection,
+                                 globalconf.screen->root,
+                                 XCB_CW_EVENT_MASK,
+                                 (uint32_t[]) { 0 });
+    root_set_wallpaper_pixmap(globalconf.connection, p);
+    xcb_change_window_attributes(globalconf.connection,
+                                 globalconf.screen->root,
+                                 XCB_CW_EVENT_MASK,
+                                 ROOT_WINDOW_EVENT_MASK);
+    xutil_ungrab_server(globalconf.connection);
+
+    /* Make sure our pixmap is not destroyed when we disconnect. */
+    xcb_set_close_down_mode(c, XCB_CLOSE_DOWN_RETAIN_PERMANENT);
+
+    /* Tell Lua that the wallpaper changed */
+    cairo_surface_destroy(globalconf.wallpaper);
+    globalconf.wallpaper = surface;
+    signal_object_emit(L, &global_signals, "wallpaper_changed", 0);
+
+    result = true;
+disconnect:
+    xcb_aux_sync(c);
+    xcb_disconnect(c);
+    return result;
+}
+
+void x11_update_wallpaper(void)
+{
+    xcb_get_property_cookie_t prop_c;
+    xcb_get_property_reply_t *prop_r;
+    xcb_get_geometry_cookie_t geom_c;
+    xcb_get_geometry_reply_t *geom_r;
+    xcb_pixmap_t *rootpix;
+
+    cairo_surface_destroy(globalconf.wallpaper);
+    globalconf.wallpaper = NULL;
+
+    prop_c = xcb_get_property_unchecked(globalconf.connection, false,
+            globalconf.screen->root, _XROOTPMAP_ID, XCB_ATOM_PIXMAP, 0, 1);
+    prop_r = xcb_get_property_reply(globalconf.connection, prop_c, NULL);
+
+    if (!prop_r || !prop_r->value_len)
+    {
+        p_delete(&prop_r);
+        return;
+    }
+
+    rootpix = xcb_get_property_value(prop_r);
+    if (!rootpix)
+    {
+        p_delete(&prop_r);
+        return;
+    }
+
+    geom_c = xcb_get_geometry_unchecked(globalconf.connection, *rootpix);
+    geom_r = xcb_get_geometry_reply(globalconf.connection, geom_c, NULL);
+    if (!geom_r)
+    {
+        p_delete(&prop_r);
+        return;
+    }
+
+    /* Only the default visual makes sense, so just the default depth */
+    if (geom_r->depth != draw_visual_depth(globalconf.screen, globalconf.default_visual->visual_id))
+        warn("Got a pixmap with depth %d, but the default depth is %d, continuing anyway",
+                geom_r->depth, draw_visual_depth(globalconf.screen, globalconf.default_visual->visual_id));
+
+    globalconf.wallpaper = cairo_xcb_surface_create(globalconf.connection,
+                                                    *rootpix,
+                                                    globalconf.default_visual,
+                                                    geom_r->width,
+                                                    geom_r->height);
+
+    p_delete(&prop_r);
+    p_delete(&geom_r);
+}
 
 void x11_grab_keys(void)
 {

--- a/x11/root.h
+++ b/x11/root.h
@@ -20,6 +20,11 @@
 #ifndef AWESOME_X11_ROOT_H
 #define AWESOME_X11_ROOT_H
 
+#include <cairo/cairo.h>
+
+int x11_set_wallpaper(cairo_pattern_t *pattern);
+void x11_update_wallpaper(void);
+
 void x11_grab_keys(void);
 
 #endif


### PR DESCRIPTION
Render the wallpaper/background using layer shell.

Currently some issues with this:

1) It uses Awesome's screen abstraction, which currently uses xwayland
   output size information, not wl_output's
2) The previous pattern uses the X11's notion of output, which as far as
   I can tell extends across all physical outputs since there's really
   only one logical output (or at least screen buffer). There might need
   to be some compatibility plugged in _somewhere_ to make this work.
3) Because of 1), it does not render on multi-head setups, but that
   should be fixed by moving that screen detection to wl_output.
4) Not entirely sure what wayland_update_wallpaper should do...
![wayland-screenshot](https://user-images.githubusercontent.com/3515754/65393964-de1e5800-dd55-11e9-96bc-8413046b2e14.png)
