### PR TITLE
Wayland output destruction -> destroy the screen

### DIFF
--- a/wayland/drawable.c
+++ b/wayland/drawable.c
@@ -43,13 +43,16 @@ void wayland_drawable_allocate(struct drawable_t *drawable)
 
 void wayland_drawable_cleanup(struct drawable_t *drawable)
 {
+    struct wayland_drawable *wayland_drawable = drawable->impl_data;
+    if (wayland_drawable == NULL)
+        return;
+
     wayland_drawable_unset_surface(drawable);
 
-    struct wayland_drawable *wayland_drawable = drawable->impl_data;
     if (wayland_drawable->wl_surface != NULL)
         wl_surface_destroy(wayland_drawable->wl_surface);
 
-    free(drawable->impl_data);
+    free(wayland_drawable);
     drawable->impl_data = NULL;
 }
 
@@ -76,7 +79,9 @@ void wayland_drawable_unset_surface(struct drawable_t *drawable)
 {
     struct wayland_drawable *wayland_drawable = drawable->impl_data;
 
-    if (wayland_drawable->wl_surface != NULL && wayland_drawable->buffer != NULL)
+    if (wayland_drawable != NULL
+            && wayland_drawable->wl_surface != NULL
+            && wayland_drawable->buffer != NULL)
     {
         wl_surface_attach(wayland_drawable->wl_surface, NULL, 0, 0);
         wl_buffer_destroy(wayland_drawable->buffer);

--- a/wayland/drawin.c
+++ b/wayland/drawin.c
@@ -111,7 +111,8 @@ void wayland_drawin_cleanup(struct drawin_t *drawin)
 {
     struct wayland_drawin *wayland_drawin = drawin->impl_data;
 
-    zwlr_layer_surface_v1_destroy(wayland_drawin->layer_surface);
+    if (wayland_drawin->layer_surface != NULL)
+        zwlr_layer_surface_v1_destroy(wayland_drawin->layer_surface);
 
     free(wayland_drawin);
     drawin->impl_data = NULL;

--- a/wayland/root.c
+++ b/wayland/root.c
@@ -42,8 +42,7 @@ struct wayland_wallpaper {
     size_t shm_size;
 };
 
-static void
-wayland_wallpaper_cleanup(struct wayland_wallpaper *wayland_wallpaper)
+void wayland_wallpaper_cleanup(struct wayland_wallpaper *wayland_wallpaper)
 {
 	zwlr_layer_surface_v1_destroy(wayland_wallpaper->layer_surface);
     wl_surface_destroy(wayland_wallpaper->wl_surface);
@@ -70,6 +69,8 @@ static void wallpaper_surface_closed(void *data,
 {
     screen_t *screen = data;
     struct wayland_screen *wayland_screen = screen->impl_data;
+    if(wayland_screen == NULL)
+        return;
     wayland_wallpaper_cleanup(wayland_screen->wallpaper);
     wayland_screen->wallpaper = NULL;
 }

--- a/wayland/root.c
+++ b/wayland/root.c
@@ -44,7 +44,9 @@ struct wayland_wallpaper {
 
 void wayland_wallpaper_cleanup(struct wayland_wallpaper *wayland_wallpaper)
 {
-	zwlr_layer_surface_v1_destroy(wayland_wallpaper->layer_surface);
+    if (wayland_wallpaper == NULL)
+        return;
+    zwlr_layer_surface_v1_destroy(wayland_wallpaper->layer_surface);
     wl_surface_destroy(wayland_wallpaper->wl_surface);
     cairo_surface_destroy(wayland_wallpaper->surface);
     free(wayland_wallpaper);

--- a/wayland/root.h
+++ b/wayland/root.h
@@ -26,8 +26,11 @@
 
 extern struct zway_cooler_keybindings_listener keybindings_listener;
 
+struct wayland_wallpaper;
+
 int wayland_set_wallpaper(cairo_pattern_t *pattern);
 void wayland_update_wallpaper(void);
+void wayland_wallpaper_cleanup(struct wayland_wallpaper *wayland_wallpaper);
 
 void wayland_grab_keys(void);
 

--- a/wayland/screen.c
+++ b/wayland/screen.c
@@ -22,6 +22,8 @@
 
 #include <stdint.h>
 
+#include "wayland/root.h"
+
 #include "xdg-output-unstable-v1.h"
 
 static struct wayland_viewport *first_screen_viewport = NULL;
@@ -171,7 +173,7 @@ static void wl_output_on_done(void *data, struct wl_output *wl_output)
         lua_State *L = globalconf_get_lua_State();
         viewport_dedupe(screen->viewport);
         screen_added(L, screen);
-        wl_display_roundtrip(globalconf.wl_display);
+        screen_schedule_refresh();
     }
 }
 
@@ -209,6 +211,8 @@ void wayland_new_screen(screen_t *screen, void *data)
 
 void wayland_wipe_screen(screen_t *screen)
 {
+    struct wayland_screen *wayland_screen = screen->impl_data;
+    wayland_wallpaper_cleanup(wayland_screen->wallpaper);
     free(screen->impl_data);
     screen->impl_data = NULL;
 }

--- a/wayland/screen.c
+++ b/wayland/screen.c
@@ -212,6 +212,8 @@ void wayland_new_screen(screen_t *screen, void *data)
 void wayland_wipe_screen(screen_t *screen)
 {
     struct wayland_screen *wayland_screen = screen->impl_data;
+    if (wayland_screen == NULL)
+        return;
     wayland_wallpaper_cleanup(wayland_screen->wallpaper);
     free(screen->impl_data);
     screen->impl_data = NULL;

--- a/wayland/screen.h
+++ b/wayland/screen.h
@@ -55,6 +55,7 @@ struct wayland_screen
     struct wl_output *wl_output;
     struct wayland_wallpaper *wallpaper;
     screen_t *screen;
+    uint32_t wl_id;
     bool configured;
 };
 


### PR DESCRIPTION
Didn't test this with multi-head output, needs to be tested before
merged (e.g. hotplugging outputs shouldn't cause a crash in the client
-- unless they are all removed since that is not supported)